### PR TITLE
Refactor/code editor

### DIFF
--- a/src/components/ide/editor-part/EditorContainer.tsx
+++ b/src/components/ide/editor-part/EditorContainer.tsx
@@ -2,16 +2,15 @@
 import { ClientSideSuspense } from "@liveblocks/react/suspense"
 import { Editor } from "@monaco-editor/react"
 import { useState } from "react"
-// import { Cursors } from "@/components/ide/editor-part/Cusors";
+//import { Cursors } from "@/components/ide/editor-part/Cursors";
 import { useCollaborativeEditor } from "@/hooks/editor/useCollaborativeEditor"
 import { LiveblocksProvider, RoomProvider, useRoom } from "@/liveblocks.config"
 import { useFileTabStore } from "@/stores/editor-file-store"
 
 const CollaborativeEditor = ({ filePath }: { filePath: string }) => {
   const room = useRoom()
-  const { handleOnMount, isLoading } =
-    //이후 커서 표시를 위해 yProvider 사용할 예정
-    useCollaborativeEditor(filePath)
+  //이후 커서 표시를 위해 yProvider 사용할 예정 const { handleOnMount, isLoading, yProvider } =
+  const { handleOnMount, isLoading } = useCollaborativeEditor(filePath)
   const expectedRoomId = `room-${filePath}`
 
   if (room.id !== expectedRoomId) {

--- a/src/hooks/editor/useAwareness.ts
+++ b/src/hooks/editor/useAwareness.ts
@@ -1,0 +1,36 @@
+import type { getYjsProviderForRoom } from "@liveblocks/yjs"
+import { useEffect, useMemo } from "react"
+import { useRoom } from "@/liveblocks.config"
+import { useUserStore } from "@/stores/user-store"
+
+/**
+ * 실시간 협업에서 사용자 상태 정보(awareness)를 관리하는 훅
+ * - 현재 사용자가 어떤 파일을 편집 중인지 다른 사용자들에게 알림
+ * - 사용자 정보, 파일 경로, 타임스탬프 등을 실시간으로 공유
+ */
+export const useAwareness = (
+  yProvider: ReturnType<typeof getYjsProviderForRoom>, // Y.js provider 인스턴스
+  filePath: string // 현재 편집 중인 파일 경로
+) => {
+  const room = useRoom() // Liveblocks 방 정보
+  const { getUserAsJsonObject } = useUserStore() // 사용자 정보를 가져오는 함수
+
+  // 사용자 정보를 JSON 객체로 변환하여 메모이제이션
+  const userJson = useMemo(() => getUserAsJsonObject(), [getUserAsJsonObject])
+
+  useEffect(() => {
+    if (userJson) {
+      // 다른 사용자들과 공유할 awareness 데이터 구성
+      const awarenessData = {
+        ...userJson, // 사용자 기본 정보 (이름, 아이디 등)
+        filePath, // 현재 편집 중인 파일 전체 경로
+        roomId: room.id, // 현재 협업 방 ID
+        timestamp: Date.now(), // 현재 시간 (마지막 활동 시간)
+      }
+
+      // Y.js awareness에 로컬 사용자 상태 설정
+      // 다른 사용자들이 이 정보를 실시간으로 볼 수 있음
+      yProvider.awareness.setLocalStateField("user", awarenessData)
+    }
+  }, [yProvider, userJson, filePath, room.id])
+}

--- a/src/hooks/editor/useAwareness.ts
+++ b/src/hooks/editor/useAwareness.ts
@@ -1,5 +1,5 @@
 import type { getYjsProviderForRoom } from "@liveblocks/yjs"
-import { useEffect, useMemo } from "react"
+import { useEffect } from "react"
 import { useRoom } from "@/liveblocks.config"
 import { useUserStore } from "@/stores/user-store"
 
@@ -13,24 +13,26 @@ export const useAwareness = (
   filePath: string // 현재 편집 중인 파일 경로
 ) => {
   const room = useRoom() // Liveblocks 방 정보
-  const { getUserAsJsonObject } = useUserStore() // 사용자 정보를 가져오는 함수
-
-  // 사용자 정보를 JSON 객체로 변환하여 메모이제이션
-  const userJson = useMemo(() => getUserAsJsonObject(), [getUserAsJsonObject])
+  const { userInfo } = useUserStore() // 사용자 정보 스토어
 
   useEffect(() => {
-    if (userJson) {
-      // 다른 사용자들과 공유할 awareness 데이터 구성
-      const awarenessData = {
-        ...userJson, // 사용자 기본 정보 (이름, 아이디 등)
-        filePath, // 현재 편집 중인 파일 전체 경로
-        roomId: room.id, // 현재 협업 방 ID
-        timestamp: Date.now(), // 현재 시간 (마지막 활동 시간)
-      }
-
-      // Y.js awareness에 로컬 사용자 상태 설정
-      // 다른 사용자들이 이 정보를 실시간으로 볼 수 있음
-      yProvider.awareness.setLocalStateField("user", awarenessData)
+    if (!userInfo) {
+      console.log("👤 사용자 정보가 아직 없음, awareness 설정 대기 중...")
+      return
     }
-  }, [yProvider, userJson, filePath, room.id])
+
+    // 다른 사용자들과 공유할 awareness 데이터 구성
+    const awarenessData = {
+      ...userInfo, // 사용자 기본 정보 (이름, 아이디 등)
+      filePath, // 현재 편집 중인 파일 전체 경로
+      roomId: room.id, // 현재 협업 방 ID
+      timestamp: Date.now(), // 현재 시간 (마지막 활동 시간)
+    }
+
+    console.log("👤 Awareness 설정:", awarenessData)
+
+    // Y.js awareness에 로컬 사용자 상태 설정
+    // 다른 사용자들이 이 정보를 실시간으로 볼 수 있음
+    yProvider.awareness.setLocalStateField("user", awarenessData)
+  }, [yProvider, userInfo, filePath, room.id])
 }

--- a/src/hooks/editor/useCollaborativeEditor.ts
+++ b/src/hooks/editor/useCollaborativeEditor.ts
@@ -1,0 +1,49 @@
+import { getYjsProviderForRoom } from "@liveblocks/yjs"
+import type { editor } from "monaco-editor"
+import { useCallback, useMemo, useState } from "react"
+import { useRoom } from "@/liveblocks.config"
+import { useAwareness } from "./useAwareness"
+import { useMonacoBinding } from "./useMonacoBinding"
+import { useUserInitialization } from "./useUserInitialization"
+
+/**
+ * 협업 에디터 기능을 통합 관리하는 메인 훅
+ * - Liveblocks + Y.js + Monaco Editor를 조합한 실시간 협업 에디터
+ * - 사용자 초기화, awareness 공유, 텍스트 동기화를 한번에 처리
+ */
+export const useCollaborativeEditor = (filePath: string) => {
+  const room = useRoom() // Liveblocks 방 인스턴스
+  const [isLoading, setIsLoading] = useState(true) // 에디터 로딩 상태
+
+  // Monaco Editor 인스턴스를 저장할 상태
+  const [localEditorRef, setLocalEditorRef] = useState<editor.IStandaloneCodeEditor | null>(null)
+
+  // Y.js provider 인스턴스 생성 및 메모이제이션
+  // 실시간 협업을 위한 핵심 객체
+  const yProvider = useMemo(() => {
+    return getYjsProviderForRoom(room)
+  }, [room])
+
+  // 사용자 초기화 (사용자 정보 설정, 인증 등)
+  useUserInitialization()
+
+  // 사용자 상태 정보(awareness) 관리
+  // 다른 사용자들에게 현재 사용자의 활동 상태 알림
+  useAwareness(yProvider, filePath)
+
+  // Monaco Editor와 Y.js 바인딩 설정
+  // 텍스트 변경사항을 실시간으로 동기화
+  useMonacoBinding(localEditorRef, yProvider)
+
+  // Monaco Editor가 마운트될 때 호출되는 콜백 함수
+  const handleOnMount = useCallback((editor: editor.IStandaloneCodeEditor) => {
+    setLocalEditorRef(editor) // 에디터 인스턴스 저장
+    setIsLoading(false) // 로딩 상태 해제
+  }, [])
+
+  return {
+    handleOnMount, // Monaco Editor 마운트 핸들러
+    isLoading, // 로딩 상태
+    yProvider, // Y.js provider (필요시 외부에서 사용)
+  }
+}

--- a/src/hooks/editor/useMonacoBinding.ts
+++ b/src/hooks/editor/useMonacoBinding.ts
@@ -1,0 +1,54 @@
+import type { getYjsProviderForRoom } from "@liveblocks/yjs"
+import type { editor } from "monaco-editor"
+import { useEffect, useRef } from "react"
+import { MonacoBinding } from "y-monaco"
+import type { Awareness } from "y-protocols/awareness.js"
+
+/**
+ * Monaco Editor와 Y.js를 바인딩하여 실시간 텍스트 동기화를 구현하는 훅
+ * - 여러 사용자가 동시에 편집할 때 텍스트 변경사항을 실시간으로 동기화
+ * - 커서 위치, 선택 영역 등도 함께 공유
+ */
+export const useMonacoBinding = (
+  localEditorRef: editor.IStandaloneCodeEditor | null, // Monaco Editor 인스턴스
+  yProvider: ReturnType<typeof getYjsProviderForRoom> // Y.js provider
+) => {
+  // MonacoBinding 인스턴스를 저장할 ref
+  const bindingRef = useRef<MonacoBinding | null>(null)
+
+  useEffect(() => {
+    // 에디터가 아직 준비되지 않았으면 바인딩 생성하지 않음
+    if (!localEditorRef) return
+
+    // 에디터의 텍스트 모델 가져오기
+    const model = localEditorRef.getModel()
+    if (!model) return
+
+    // 기존 바인딩이 있다면 정리
+    if (bindingRef.current) {
+      bindingRef.current.destroy()
+    }
+
+    // Y.js 문서에서 "monaco"라는 이름의 텍스트 객체 가져오기
+    // 이 객체가 실제로 동기화되는 텍스트 데이터
+    const yText = yProvider.getYDoc().getText("monaco")
+
+    // Monaco Editor와 Y.js 텍스트를 바인딩
+    const binding = new MonacoBinding(
+      yText, // Y.js 텍스트 객체
+      model as editor.ITextModel, // Monaco Editor 모델
+      new Set([localEditorRef]), // 바인딩할 에디터 인스턴스들
+      yProvider.awareness as unknown as Awareness // 사용자 상태 정보 (커서, 선택 등)
+    )
+
+    bindingRef.current = binding
+
+    // 정리 함수: 컴포넌트 언마운트 시 바인딩 해제
+    return () => {
+      if (bindingRef.current) {
+        bindingRef.current.destroy()
+        bindingRef.current = null
+      }
+    }
+  }, [localEditorRef, yProvider]) // 에디터나 provider가 변경될 때마다 재바인딩
+}

--- a/src/hooks/editor/useUserInitialization.ts
+++ b/src/hooks/editor/useUserInitialization.ts
@@ -1,0 +1,18 @@
+import { useEffect } from "react"
+import { useUserStore } from "@/stores/user-store"
+
+/**
+ * 협업 에디터용 사용자 정보 초기화 훅
+ * - 초기 상태에서 userInfo가 null이므로 임시 사용자 정보를 자동 생성
+ * - 로그인 없이도 협업 기능 사용 가능하도록 랜덤 ID/색상 할당
+ * - Liveblocks awareness에서 사용자 구분을 위해 필수
+ * - userstore에서 사용자 정보를 입력-이후 커서에 반영
+ */
+export const useUserInitialization = () => {
+  const { userInfo, initializeUser } = useUserStore()
+
+  useEffect(() => {
+    // 사용자 정보가 없으면 초기화 실행
+    if (!userInfo) initializeUser()
+  }, [userInfo, initializeUser])
+}

--- a/src/stores/user-store.ts
+++ b/src/stores/user-store.ts
@@ -20,12 +20,14 @@ export const useUserStore = create<UserStore>((set, get) => ({
   },
 
   initializeUser: () => {
+    // TODO: 실제 로그인된 사용자 정보를 가져와야 함
+    // 현재는 임시 데이터로 하드코딩
     const userInfo: UserInfo = {
-      color: `#${Math.floor(Math.random() * 16777215).toString(16)}`, // 랜덤 HEX 색상
-      id: Math.random().toString(36).substr(2, 9), // 랜덤 9자리 ID
-      name: "유저1", // 기본 사용자명
+      color: `#${Math.floor(Math.random() * 16777215).toString(16)}`,
+      id: "userData.email", // 실제로는 로그인한 사용자의 이메일
+      name: "userData.name", // 실제로는 로그인한 사용자의 닉네임
     }
-    set({ userInfo }) // 스토어에 저장
+    set({ userInfo })
   },
   userInfo: null,
 }))

--- a/src/stores/user-store.ts
+++ b/src/stores/user-store.ts
@@ -5,6 +5,7 @@ export interface UserInfo {
   id: string // 사용자 고유 식별자
   name: string // 사용자 표시 이름
   color: string // 협업시 커서/하이라이트 색상
+  role?: string // 편집 등 권한
 }
 
 interface UserStore {
@@ -26,6 +27,7 @@ export const useUserStore = create<UserStore>((set, get) => ({
       color: `#${Math.floor(Math.random() * 16777215).toString(16)}`,
       id: "userData.email", // 실제로는 로그인한 사용자의 이메일
       name: "userData.name", // 실제로는 로그인한 사용자의 닉네임
+      role: "editor", // 편집과 읽기 권한 여부
     }
     set({ userInfo })
   },

--- a/src/stores/user-store.ts
+++ b/src/stores/user-store.ts
@@ -2,16 +2,25 @@ import type { JsonObject } from "@liveblocks/client"
 import { create } from "zustand"
 
 export interface UserInfo {
-  id: string // 사용자 고유 식별자
+  id: string // 사용자 고유 식별자 (이메일)
   name: string // 사용자 표시 이름
-  color: string // 협업시 커서/하이라이트 색상
-  role?: string // 편집 등 권한
+  color: string // 협업 시 커서/하이라이트 색상 (hex 형식)
 }
 
 interface UserStore {
   userInfo: UserInfo | null // 현재 사용자 정보
-  getUserAsJsonObject: () => JsonObject | null // 라이브블록용 JSON 변환
-  initializeUser: () => void // 사용자 초기화
+
+  /**
+   * 사용자 정보를 Liveblocks에서 사용 가능한 JSON 형태로 변환합니다
+   * @returns JsonObject | null - 변환된 사용자 정보 또는 null (로그인하지 않은 경우)
+   */
+  getUserAsJsonObject: () => JsonObject | null
+
+  /**
+   * localStorage에서 사용자 정보를 로드하여 초기화합니다.
+   * 저장된 정보가 없는 경우 개발용 임시 데이터를 사용합니다.
+   */
+  initializeUser: () => void
 }
 
 export const useUserStore = create<UserStore>((set, get) => ({
@@ -21,15 +30,17 @@ export const useUserStore = create<UserStore>((set, get) => ({
   },
 
   initializeUser: () => {
-    // TODO: 실제 로그인된 사용자 정보를 가져와야 함
-    // 현재는 임시 데이터로 하드코딩
+    const storedData = localStorage.getItem("userInfo")
+    const userData = storedData ? JSON.parse(storedData) : null
+
     const userInfo: UserInfo = {
-      color: `#${Math.floor(Math.random() * 16777215).toString(16)}`,
-      id: "userData.email", // 실제로는 로그인한 사용자의 이메일
-      name: "userData.name", // 실제로는 로그인한 사용자의 닉네임
-      role: "editor", // 편집과 읽기 권한 여부
+      // 기존 색상 유지, 없으면 랜덤 생성
+      color: userData?.color || `#${Math.floor(Math.random() * 16777215).toString(16)}`,
+      id: userData?.email || "test@example.com", // 개발용 임시 데이터
+      name: userData?.name || "테스트 사용자", // 개발용 임시 데이터
     }
     set({ userInfo })
   },
+
   userInfo: null,
 }))


### PR DESCRIPTION
## 개요

이전에 EditorContainer.tsx (코드 에디터)에 존재했던 라이브 블록 라이브러리와 모나코 에디터 관련 부분을 훅으로 분리했습니다.
코드 구조만 바꾸면서 약간 최적화만 한거라 기능적으로는 거의 동일합니다.

추가적으로 openTabs.map(tab => ()을 추가해서 탭 변경 시 파일이 언마운트되지 않도록 수정했습니다.(이후 스플릿등 기능 추가를 위함)

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

EditorContainer.tsx
- 변경사항은 기존 내부 코드를 역할에 맞게 훅으로 변경한 부분입니다.
- 추가적으로 에디터 언마운트를 위해서 openTabs.map(tab => ()로 간단하게 초기 설정만했습니다.
- 이후 커서 기능을 추가하여 pr할 생각입니다.(구현은 완료)

useCollaborativeEditor
- 협업 에디터의 모든 기능을 통합하여 관리하는 메인 훅

이하 3개의 훅(라이브블록 기능을 처리하고 유저 정보를 받아오는 훅)
- 라이브러리 사용관련 부분이라 코드만으로 파악이 어려워서 상세 설명 주석을 달았습니다.
useAwareness
- 현재 사용자의 상태(파일명, 위치 등)를 다른 사용자들과 실시간 공유
- 실질적으로 외부에서 사용될 부분은 현재 어떤 파일을 사용자가 편집하고 있는지에 대한 부분입니다.

useMonacoBinding
- Monaco Editor의 텍스트와 Y.js를 연결하여 실시간 텍스트 동기화 구현

useUserInitialization
- 유저 정보를 초기화하는 부분
- 최초에 계정 정보를 여기에 넣어서 식별자(커서 등)로 사용할 수 있을 것으로 보입니다.

stores/user-store.ts
- 정보 입력 부분을 현재 어떤 정보를 입력해야하는 지 하드코딩 처리했습니다.

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] Eslint 및 Prettier 규칙을 준수했습니다.
- [ ] origin/main에서의 최신 커밋을 확인하고 반영했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
