### PR TITLE
[IDE-111] 사용자 커서 구현

### DIFF
--- a/src/components/ide/editor-part/Cursors.tsx
+++ b/src/components/ide/editor-part/Cursors.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect } from "react"
 import type { UserInfo } from "@/stores/user-store"
 import "@/styles/Cursors.css"
+import { useUserStore } from "@/stores/user-store"
 
 interface YjsProvider {
   awareness: {
@@ -18,6 +19,12 @@ const CURSOR_STYLES_ID = "collaborative-cursor-styles"
 const isValidColor = (color: string): boolean => /^#[0-9a-fA-F]{6}$/.test(color)
 
 export const Cursors = ({ yProvider }: Props) => {
+  // 라벨 on/off 버튼과 초기 상태 가져오기
+  const { labelsVisible } = useUserStore()
+  useEffect(() => {
+    document.body.classList.toggle("labels-hidden", !labelsVisible)
+  }, [labelsVisible])
+
   // 협업 커서 스타일 생성 및 업데이트
   const renderCursorStyles = useCallback(() => {
     // 기존 스타일 제거 (중복 방지)
@@ -27,21 +34,27 @@ export const Cursors = ({ yProvider }: Props) => {
 
     // 현재 접속 중인 모든 사용자의 커서 스타일 생성
     const cursorStyles = [...yProvider.awareness.getStates()]
-      .map(([userId, clientState]) => {
+      .map(([clientId, clientState]) => {
         const user = (clientState as { user?: UserInfo })?.user
         if (!user?.name || !user?.color || !isValidColor(user.color)) return ""
 
         // 사용자 이름 안전 처리 (특수문자 이스케이프)
         const userName = user.name.slice(0, 20).replace(/['"\\]/g, "\\$&")
+        const email = user.email.replace(/['"\\]/g, "\\$&") // 🔥 이메일도 이스케이프
 
         // 사용자별 커서 스타일 정의
         return `
-          .yRemoteSelection-${userId} { background-color: ${user.color}40 !important; }
-          .yRemoteSelectionHead-${userId}::before { background-color: ${user.color} !important; }
-          .yRemoteSelectionHead-${userId}::after { 
-            content: "${userName}" !important; 
-            background: ${user.color} !important; 
-          }`
+        .yRemoteSelection-${clientId}, 
+        .yRemoteSelectionHead-${clientId} {
+          --user-color: ${user.color};
+        }
+        
+        .yRemoteSelectionHead-${clientId}::after {
+          content: "${userName}";
+        }
+        .yRemoteSelectionHead-${clientId}:hover::after {
+          content: "${userName} (${email})";
+        }`
       })
       .filter(Boolean)
       .join("")

--- a/src/components/ide/editor-part/Cursors.tsx
+++ b/src/components/ide/editor-part/Cursors.tsx
@@ -1,0 +1,74 @@
+import { useCallback, useEffect } from "react"
+import type { UserInfo } from "@/stores/user-store"
+import "@/styles/Cursors.css"
+
+interface YjsProvider {
+  awareness: {
+    getStates: () => Map<number, unknown>
+    on: (event: string, callback: () => void) => void
+    off: (event: string, callback: () => void) => void
+  }
+}
+
+interface Props {
+  yProvider: YjsProvider
+}
+
+const CURSOR_STYLES_ID = "collaborative-cursor-styles"
+const isValidColor = (color: string): boolean => /^#[0-9a-fA-F]{6}$/.test(color)
+
+export const Cursors = ({ yProvider }: Props) => {
+  // 협업 커서 스타일 생성 및 업데이트
+  const renderCursorStyles = useCallback(() => {
+    // 기존 스타일 제거 (중복 방지)
+    document.getElementById(CURSOR_STYLES_ID)?.remove()
+
+    if (!yProvider?.awareness) return
+
+    // 현재 접속 중인 모든 사용자의 커서 스타일 생성
+    const cursorStyles = [...yProvider.awareness.getStates()]
+      .map(([userId, clientState]) => {
+        const user = (clientState as { user?: UserInfo })?.user
+        if (!user?.name || !user?.color || !isValidColor(user.color)) return ""
+
+        // 사용자 이름 안전 처리 (특수문자 이스케이프)
+        const userName = user.name.slice(0, 20).replace(/['"\\]/g, "\\$&")
+
+        // 사용자별 커서 스타일 정의
+        return `
+          .yRemoteSelection-${userId} { background-color: ${user.color}40 !important; }
+          .yRemoteSelectionHead-${userId}::before { background-color: ${user.color} !important; }
+          .yRemoteSelectionHead-${userId}::after { 
+            content: "${userName}" !important; 
+            background: ${user.color} !important; 
+          }`
+      })
+      .filter(Boolean)
+      .join("")
+
+    // 스타일이 있으면 DOM에 추가
+    if (cursorStyles) {
+      const styleElement = document.createElement("style")
+      styleElement.id = CURSOR_STYLES_ID
+      styleElement.textContent = cursorStyles
+      document.head.appendChild(styleElement)
+    }
+  }, [yProvider])
+
+  useEffect(() => {
+    if (!yProvider?.awareness) return
+
+    // awareness 변경 이벤트 등록 (사용자 입/퇴장, 커서 이동 등)
+    yProvider.awareness.on("change", renderCursorStyles)
+    // 초기 커서 스타일 렌더링
+    renderCursorStyles()
+
+    return () => {
+      // 이벤트 리스너 제거 및 스타일 정리
+      yProvider.awareness.off("change", renderCursorStyles)
+      document.getElementById(CURSOR_STYLES_ID)?.remove()
+    }
+  }, [yProvider, renderCursorStyles])
+
+  return null
+}

--- a/src/components/ide/editor-part/EditorContainer.tsx
+++ b/src/components/ide/editor-part/EditorContainer.tsx
@@ -47,7 +47,9 @@ const CollaborativeEditor = ({ filePath }: { filePath: string }) => {
         options={{
           automaticLayout: true,
           fontSize: 14,
+          hover: { delay: 500, enabled: true, sticky: false },
           lineNumbers: "on",
+          padding: { bottom: 0, top: 30 },
           tabSize: 2,
           wordWrap: "on",
         }}

--- a/src/components/ide/editor-part/EditorContainer.tsx
+++ b/src/components/ide/editor-part/EditorContainer.tsx
@@ -2,16 +2,15 @@
 import { ClientSideSuspense } from "@liveblocks/react/suspense"
 import { Editor } from "@monaco-editor/react"
 import { useState } from "react"
-// import { Cursors } from "@/components/ide/editor-part/Cusors";
+//import { Cursors } from "@/components/ide/editor-part/Cursors";
 import { useCollaborativeEditor } from "@/hooks/editor/useCollaborativeEditor"
 import { LiveblocksProvider, RoomProvider, useRoom } from "@/liveblocks.config"
 import { useFileTabStore } from "@/stores/editor-file-store"
 
 const CollaborativeEditor = ({ filePath }: { filePath: string }) => {
   const room = useRoom()
-  const { handleOnMount, isLoading } =
-    //이후 커서 표시를 위해 yProvider 사용할 예정
-    useCollaborativeEditor(filePath)
+  //이후 커서 표시를 위해 yProvider 사용할 예정 const { handleOnMount, isLoading, yProvider } =
+  const { handleOnMount, isLoading } = useCollaborativeEditor(filePath)
   const expectedRoomId = `room-${filePath}`
 
   if (room.id !== expectedRoomId) {

--- a/src/components/ide/editor-part/EditorContainer.tsx
+++ b/src/components/ide/editor-part/EditorContainer.tsx
@@ -2,15 +2,15 @@
 import { ClientSideSuspense } from "@liveblocks/react/suspense"
 import { Editor } from "@monaco-editor/react"
 import { useState } from "react"
-//import { Cursors } from "@/components/ide/editor-part/Cursors";
+import { Cursors } from "@/components/ide/editor-part/Cursors"
 import { useCollaborativeEditor } from "@/hooks/editor/useCollaborativeEditor"
 import { LiveblocksProvider, RoomProvider, useRoom } from "@/liveblocks.config"
 import { useFileTabStore } from "@/stores/editor-file-store"
 
 const CollaborativeEditor = ({ filePath }: { filePath: string }) => {
   const room = useRoom()
-  //이후 커서 표시를 위해 yProvider 사용할 예정 const { handleOnMount, isLoading, yProvider } =
-  const { handleOnMount, isLoading } = useCollaborativeEditor(filePath)
+
+  const { handleOnMount, isLoading, yProvider } = useCollaborativeEditor(filePath)
   const expectedRoomId = `room-${filePath}`
 
   if (room.id !== expectedRoomId) {
@@ -29,7 +29,7 @@ const CollaborativeEditor = ({ filePath }: { filePath: string }) => {
 
   return (
     <div className="relative h-full">
-      {/*todo : <Cursors yProvider={yProvider} />*/}
+      <Cursors yProvider={yProvider} />
       {isLoading && (
         <div className="absolute inset-0 z-10 flex items-center justify-center bg-white/80">
           <div className="flex items-center gap-2">

--- a/src/hooks/editor/useAwareness.ts
+++ b/src/hooks/editor/useAwareness.ts
@@ -1,0 +1,36 @@
+import type { getYjsProviderForRoom } from "@liveblocks/yjs"
+import { useEffect, useMemo } from "react"
+import { useRoom } from "@/liveblocks.config"
+import { useUserStore } from "@/stores/user-store"
+
+/**
+ * 실시간 협업에서 사용자 상태 정보(awareness)를 관리하는 훅
+ * - 현재 사용자가 어떤 파일을 편집 중인지 다른 사용자들에게 알림
+ * - 사용자 정보, 파일 경로, 타임스탬프 등을 실시간으로 공유
+ */
+export const useAwareness = (
+  yProvider: ReturnType<typeof getYjsProviderForRoom>, // Y.js provider 인스턴스
+  filePath: string // 현재 편집 중인 파일 경로
+) => {
+  const room = useRoom() // Liveblocks 방 정보
+  const { getUserAsJsonObject } = useUserStore() // 사용자 정보를 가져오는 함수
+
+  // 사용자 정보를 JSON 객체로 변환하여 메모이제이션
+  const userJson = useMemo(() => getUserAsJsonObject(), [getUserAsJsonObject])
+
+  useEffect(() => {
+    if (userJson) {
+      // 다른 사용자들과 공유할 awareness 데이터 구성
+      const awarenessData = {
+        ...userJson, // 사용자 기본 정보 (이름, 아이디 등)
+        filePath, // 현재 편집 중인 파일 전체 경로
+        roomId: room.id, // 현재 협업 방 ID
+        timestamp: Date.now(), // 현재 시간 (마지막 활동 시간)
+      }
+
+      // Y.js awareness에 로컬 사용자 상태 설정
+      // 다른 사용자들이 이 정보를 실시간으로 볼 수 있음
+      yProvider.awareness.setLocalStateField("user", awarenessData)
+    }
+  }, [yProvider, userJson, filePath, room.id])
+}

--- a/src/hooks/editor/useAwareness.ts
+++ b/src/hooks/editor/useAwareness.ts
@@ -1,5 +1,5 @@
 import type { getYjsProviderForRoom } from "@liveblocks/yjs"
-import { useEffect, useMemo } from "react"
+import { useEffect } from "react"
 import { useRoom } from "@/liveblocks.config"
 import { useUserStore } from "@/stores/user-store"
 
@@ -13,24 +13,26 @@ export const useAwareness = (
   filePath: string // 현재 편집 중인 파일 경로
 ) => {
   const room = useRoom() // Liveblocks 방 정보
-  const { getUserAsJsonObject } = useUserStore() // 사용자 정보를 가져오는 함수
-
-  // 사용자 정보를 JSON 객체로 변환하여 메모이제이션
-  const userJson = useMemo(() => getUserAsJsonObject(), [getUserAsJsonObject])
+  const { userInfo } = useUserStore() // 사용자 정보 스토어
 
   useEffect(() => {
-    if (userJson) {
-      // 다른 사용자들과 공유할 awareness 데이터 구성
-      const awarenessData = {
-        ...userJson, // 사용자 기본 정보 (이름, 아이디 등)
-        filePath, // 현재 편집 중인 파일 전체 경로
-        roomId: room.id, // 현재 협업 방 ID
-        timestamp: Date.now(), // 현재 시간 (마지막 활동 시간)
-      }
-
-      // Y.js awareness에 로컬 사용자 상태 설정
-      // 다른 사용자들이 이 정보를 실시간으로 볼 수 있음
-      yProvider.awareness.setLocalStateField("user", awarenessData)
+    if (!userInfo) {
+      console.log("👤 사용자 정보가 아직 없음, awareness 설정 대기 중...")
+      return
     }
-  }, [yProvider, userJson, filePath, room.id])
+
+    // 다른 사용자들과 공유할 awareness 데이터 구성
+    const awarenessData = {
+      ...userInfo, // 사용자 기본 정보 (이름, 아이디 등)
+      filePath, // 현재 편집 중인 파일 전체 경로
+      roomId: room.id, // 현재 협업 방 ID
+      timestamp: Date.now(), // 현재 시간 (마지막 활동 시간)
+    }
+
+    console.log("👤 Awareness 설정:", awarenessData)
+
+    // Y.js awareness에 로컬 사용자 상태 설정
+    // 다른 사용자들이 이 정보를 실시간으로 볼 수 있음
+    yProvider.awareness.setLocalStateField("user", awarenessData)
+  }, [yProvider, userInfo, filePath, room.id])
 }

--- a/src/hooks/editor/useCollaborativeEditor.ts
+++ b/src/hooks/editor/useCollaborativeEditor.ts
@@ -1,0 +1,49 @@
+import { getYjsProviderForRoom } from "@liveblocks/yjs"
+import type { editor } from "monaco-editor"
+import { useCallback, useMemo, useState } from "react"
+import { useRoom } from "@/liveblocks.config"
+import { useAwareness } from "./useAwareness"
+import { useMonacoBinding } from "./useMonacoBinding"
+import { useUserInitialization } from "./useUserInitialization"
+
+/**
+ * 협업 에디터 기능을 통합 관리하는 메인 훅
+ * - Liveblocks + Y.js + Monaco Editor를 조합한 실시간 협업 에디터
+ * - 사용자 초기화, awareness 공유, 텍스트 동기화를 한번에 처리
+ */
+export const useCollaborativeEditor = (filePath: string) => {
+  const room = useRoom() // Liveblocks 방 인스턴스
+  const [isLoading, setIsLoading] = useState(true) // 에디터 로딩 상태
+
+  // Monaco Editor 인스턴스를 저장할 상태
+  const [localEditorRef, setLocalEditorRef] = useState<editor.IStandaloneCodeEditor | null>(null)
+
+  // Y.js provider 인스턴스 생성 및 메모이제이션
+  // 실시간 협업을 위한 핵심 객체
+  const yProvider = useMemo(() => {
+    return getYjsProviderForRoom(room)
+  }, [room])
+
+  // 사용자 초기화 (사용자 정보 설정, 인증 등)
+  useUserInitialization()
+
+  // 사용자 상태 정보(awareness) 관리
+  // 다른 사용자들에게 현재 사용자의 활동 상태 알림
+  useAwareness(yProvider, filePath)
+
+  // Monaco Editor와 Y.js 바인딩 설정
+  // 텍스트 변경사항을 실시간으로 동기화
+  useMonacoBinding(localEditorRef, yProvider)
+
+  // Monaco Editor가 마운트될 때 호출되는 콜백 함수
+  const handleOnMount = useCallback((editor: editor.IStandaloneCodeEditor) => {
+    setLocalEditorRef(editor) // 에디터 인스턴스 저장
+    setIsLoading(false) // 로딩 상태 해제
+  }, [])
+
+  return {
+    handleOnMount, // Monaco Editor 마운트 핸들러
+    isLoading, // 로딩 상태
+    yProvider, // Y.js provider (필요시 외부에서 사용)
+  }
+}

--- a/src/hooks/editor/useMonacoBinding.ts
+++ b/src/hooks/editor/useMonacoBinding.ts
@@ -1,0 +1,54 @@
+import type { getYjsProviderForRoom } from "@liveblocks/yjs"
+import type { editor } from "monaco-editor"
+import { useEffect, useRef } from "react"
+import { MonacoBinding } from "y-monaco"
+import type { Awareness } from "y-protocols/awareness.js"
+
+/**
+ * Monaco Editor와 Y.js를 바인딩하여 실시간 텍스트 동기화를 구현하는 훅
+ * - 여러 사용자가 동시에 편집할 때 텍스트 변경사항을 실시간으로 동기화
+ * - 커서 위치, 선택 영역 등도 함께 공유
+ */
+export const useMonacoBinding = (
+  localEditorRef: editor.IStandaloneCodeEditor | null, // Monaco Editor 인스턴스
+  yProvider: ReturnType<typeof getYjsProviderForRoom> // Y.js provider
+) => {
+  // MonacoBinding 인스턴스를 저장할 ref
+  const bindingRef = useRef<MonacoBinding | null>(null)
+
+  useEffect(() => {
+    // 에디터가 아직 준비되지 않았으면 바인딩 생성하지 않음
+    if (!localEditorRef) return
+
+    // 에디터의 텍스트 모델 가져오기
+    const model = localEditorRef.getModel()
+    if (!model) return
+
+    // 기존 바인딩이 있다면 정리
+    if (bindingRef.current) {
+      bindingRef.current.destroy()
+    }
+
+    // Y.js 문서에서 "monaco"라는 이름의 텍스트 객체 가져오기
+    // 이 객체가 실제로 동기화되는 텍스트 데이터
+    const yText = yProvider.getYDoc().getText("monaco")
+
+    // Monaco Editor와 Y.js 텍스트를 바인딩
+    const binding = new MonacoBinding(
+      yText, // Y.js 텍스트 객체
+      model as editor.ITextModel, // Monaco Editor 모델
+      new Set([localEditorRef]), // 바인딩할 에디터 인스턴스들
+      yProvider.awareness as unknown as Awareness // 사용자 상태 정보 (커서, 선택 등)
+    )
+
+    bindingRef.current = binding
+
+    // 정리 함수: 컴포넌트 언마운트 시 바인딩 해제
+    return () => {
+      if (bindingRef.current) {
+        bindingRef.current.destroy()
+        bindingRef.current = null
+      }
+    }
+  }, [localEditorRef, yProvider]) // 에디터나 provider가 변경될 때마다 재바인딩
+}

--- a/src/hooks/editor/useUserInitialization.ts
+++ b/src/hooks/editor/useUserInitialization.ts
@@ -1,0 +1,18 @@
+import { useEffect } from "react"
+import { useUserStore } from "@/stores/user-store"
+
+/**
+ * 협업 에디터용 사용자 정보 초기화 훅
+ * - 초기 상태에서 userInfo가 null이므로 임시 사용자 정보를 자동 생성
+ * - 로그인 없이도 협업 기능 사용 가능하도록 랜덤 ID/색상 할당
+ * - Liveblocks awareness에서 사용자 구분을 위해 필수
+ * - userstore에서 사용자 정보를 입력-이후 커서에 반영
+ */
+export const useUserInitialization = () => {
+  const { userInfo, initializeUser } = useUserStore()
+
+  useEffect(() => {
+    // 사용자 정보가 없으면 초기화 실행
+    if (!userInfo) initializeUser()
+  }, [userInfo, initializeUser])
+}

--- a/src/stores/user-store.ts
+++ b/src/stores/user-store.ts
@@ -20,12 +20,14 @@ export const useUserStore = create<UserStore>((set, get) => ({
   },
 
   initializeUser: () => {
+    // TODO: 실제 로그인된 사용자 정보를 가져와야 함
+    // 현재는 임시 데이터로 하드코딩
     const userInfo: UserInfo = {
-      color: `#${Math.floor(Math.random() * 16777215).toString(16)}`, // 랜덤 HEX 색상
-      id: Math.random().toString(36).substr(2, 9), // 랜덤 9자리 ID
-      name: "유저1", // 기본 사용자명
+      color: `#${Math.floor(Math.random() * 16777215).toString(16)}`,
+      id: "userData.email", // 실제로는 로그인한 사용자의 이메일
+      name: "userData.name", // 실제로는 로그인한 사용자의 닉네임
     }
-    set({ userInfo }) // 스토어에 저장
+    set({ userInfo })
   },
   userInfo: null,
 }))

--- a/src/stores/user-store.ts
+++ b/src/stores/user-store.ts
@@ -5,6 +5,7 @@ export interface UserInfo {
   id: string // 사용자 고유 식별자
   name: string // 사용자 표시 이름
   color: string // 협업시 커서/하이라이트 색상
+  role?: string // 편집 등 권한
 }
 
 interface UserStore {
@@ -26,6 +27,7 @@ export const useUserStore = create<UserStore>((set, get) => ({
       color: `#${Math.floor(Math.random() * 16777215).toString(16)}`,
       id: "userData.email", // 실제로는 로그인한 사용자의 이메일
       name: "userData.name", // 실제로는 로그인한 사용자의 닉네임
+      role: "editor", // 편집과 읽기 권한 여부
     }
     set({ userInfo })
   },

--- a/src/stores/user-store.ts
+++ b/src/stores/user-store.ts
@@ -1,46 +1,81 @@
 import type { JsonObject } from "@liveblocks/client"
 import { create } from "zustand"
+import { persist } from "zustand/middleware"
 
 export interface UserInfo {
-  id: string // 사용자 고유 식별자 (이메일)
-  name: string // 사용자 표시 이름
-  color: string // 협업 시 커서/하이라이트 색상 (hex 형식)
+  email: string // 사용자 이메일 (고유 식별자)
+  name: string // 화면에 표시될 사용자 이름
+  color?: string // 협업 시 커서 색상 (hex), 계정 단위로 색상설정을 저장할수도 있어서 일단 매개변수로 받음
 }
 
 interface UserStore {
-  userInfo: UserInfo | null // 현재 사용자 정보
+  userInfo: UserInfo | null // 현재 로그인된 사용자 정보
+  labelsVisible: boolean // 커서 보임/숨김
+  /**
+   * 커서 라벨 표시/숨김 토글
+   */
+  toggleCursorLabels: () => void
 
   /**
-   * 사용자 정보를 Liveblocks에서 사용 가능한 JSON 형태로 변환합니다
-   * @returns JsonObject | null - 변환된 사용자 정보 또는 null (로그인하지 않은 경우)
+   * Liveblocks API 호환 형태로 사용자 정보 반환
+   * @returns 사용자 정보 객체 또는 null (미로그인)
    */
   getUserAsJsonObject: () => JsonObject | null
 
   /**
-   * localStorage에서 사용자 정보를 로드하여 초기화합니다.
-   * 저장된 정보가 없는 경우 개발용 임시 데이터를 사용합니다.
+   * 사용자 정보 업데이트(계정 정보를 받아오는 쪽에서 호출)
+   */
+  setUserInfo: (userInfo: UserInfo) => void
+
+  /**
+   * 임시 사용자로 초기화 (첫 방문자 또는 게스트 모드용)
    */
   initializeUser: () => void
 }
 
-export const useUserStore = create<UserStore>((set, get) => ({
-  getUserAsJsonObject: () => {
-    const { userInfo } = get()
-    return userInfo ? (userInfo as unknown as JsonObject) : null
-  },
+export const useUserStore = create<UserStore>()(
+  persist(
+    (set, get) => ({
+      getUserAsJsonObject: () => {
+        const { userInfo } = get()
+        return userInfo ? (userInfo as unknown as JsonObject) : null
+      },
 
-  initializeUser: () => {
-    const storedData = localStorage.getItem("userInfo")
-    const userData = storedData ? JSON.parse(storedData) : null
+      initializeUser: () => {
+        const { userInfo } = get()
+        // 이미 사용자 정보가 있으면 건너뛰기
+        if (userInfo) return
 
-    const userInfo: UserInfo = {
-      // 기존 색상 유지, 없으면 랜덤 생성
-      color: userData?.color || `#${Math.floor(Math.random() * 16777215).toString(16)}`,
-      id: userData?.email || "test@example.com", // 개발용 임시 데이터
-      name: userData?.name || "테스트 사용자", // 개발용 임시 데이터
+        // 사용자 정보가 없다면 임시 사용자 정보 생성
+        const newUserInfo: UserInfo = {
+          color: `#${Math.floor(Math.random() * 16777215).toString(16)}`,
+          email: "guest@example.com", // 게스트 사용자임을 명확히
+          name: "게스트 사용자",
+        }
+        set({ userInfo: newUserInfo })
+      },
+      labelsVisible: true, // 기본값
+
+      setUserInfo: userInfo => {
+        // 🔥 색상이 없으면 랜덤 색상 추가
+        const userInfoWithColor = {
+          ...userInfo,
+          color: userInfo.color || `#${Math.floor(Math.random() * 16777215).toString(16)}`,
+        }
+        set({ userInfo: userInfoWithColor })
+      },
+
+      toggleCursorLabels: () => {
+        const { labelsVisible } = get()
+        const newState = !labelsVisible
+
+        set({ labelsVisible: newState })
+        document.body.classList.toggle("labels-hidden", !newState)
+      },
+      userInfo: null,
+    }),
+    {
+      name: "userInfo", // localStorage 저장 키
     }
-    set({ userInfo })
-  },
-
-  userInfo: null,
-}))
+  )
+)

--- a/src/stores/user-store.ts
+++ b/src/stores/user-store.ts
@@ -2,16 +2,25 @@ import type { JsonObject } from "@liveblocks/client"
 import { create } from "zustand"
 
 export interface UserInfo {
-  id: string // 사용자 고유 식별자
+  id: string // 사용자 고유 식별자 (이메일)
   name: string // 사용자 표시 이름
-  color: string // 협업시 커서/하이라이트 색상
-  role?: string // 편집 등 권한
+  color: string // 협업 시 커서/하이라이트 색상 (hex 형식)
 }
 
 interface UserStore {
   userInfo: UserInfo | null // 현재 사용자 정보
-  getUserAsJsonObject: () => JsonObject | null // 라이브블록용 JSON 변환
-  initializeUser: () => void // 사용자 초기화
+
+  /**
+   * 사용자 정보를 Liveblocks에서 사용 가능한 JSON 형태로 변환합니다
+   * @returns JsonObject | null - 변환된 사용자 정보 또는 null (로그인하지 않은 경우)
+   */
+  getUserAsJsonObject: () => JsonObject | null
+
+  /**
+   * localStorage에서 사용자 정보를 로드하여 초기화합니다.
+   * 저장된 정보가 없는 경우 개발용 임시 데이터를 사용합니다.
+   */
+  initializeUser: () => void
 }
 
 export const useUserStore = create<UserStore>((set, get) => ({
@@ -21,15 +30,17 @@ export const useUserStore = create<UserStore>((set, get) => ({
   },
 
   initializeUser: () => {
-    // TODO: 실제 로그인된 사용자 정보를 가져와야 함
-    // 현재는 임시 데이터로 하드코딩
+    const storedData = localStorage.getItem("userInfo")
+    const userData = storedData ? JSON.parse(storedData) : null
+
     const userInfo: UserInfo = {
-      color: `#${Math.floor(Math.random() * 16777215).toString(16)}`,
-      id: "userData.email", // 실제로는 로그인한 사용자의 이메일
-      name: "userData.name", // 실제로는 로그인한 사용자의 닉네임
-      role: "editor", // 편집과 읽기 권한 여부
+      // 기존 색상 유지, 없으면 랜덤 생성
+      color: userData?.color || `#${Math.floor(Math.random() * 16777215).toString(16)}`,
+      id: userData?.email || "test@example.com", // 개발용 임시 데이터
+      name: userData?.name || "테스트 사용자", // 개발용 임시 데이터
     }
     set({ userInfo })
   },
+
   userInfo: null,
 }))

--- a/src/styles/Cursors.css
+++ b/src/styles/Cursors.css
@@ -4,7 +4,7 @@
   height: 100% !important;
   padding: 4px !important;
   margin: -2px !important;
-  border-left: 2px solid var(--user-color, orangered) !important;  
+  border-left: 2px solid var(--user-color, orangered) !important;
 }
 
 /* 라벨 */
@@ -14,7 +14,10 @@
   left: -2px !important;
   z-index: 100 !important;
   padding: 2px 6px !important;
-  font: 600 8px/normal system-ui, -apple-system, sans-serif;
+  font:
+    600 8px / normal system-ui,
+    -apple-system,
+    sans-serif;
   color: white !important;
   white-space: nowrap !important;
   pointer-events: auto !important;
@@ -28,7 +31,10 @@
 
 /* 커서에 hover 시 라벨 표시 */
 [class*="yRemoteSelectionHead-"]:hover::after {
-  font: 600 12px/normal system-ui, -apple-system, sans-serif;
+  font:
+    600 12px / normal system-ui,
+    -apple-system,
+    sans-serif;
 }
 
 /* 호버중에 린트 미표시 */
@@ -49,7 +55,7 @@ body.labels-hidden [class*="yRemoteSelectionHead-"]:after {
 
 @media (max-width: 768px) {
   [class^="yRemoteSelectionHead"]::after {
-    left: -2px !important;  /* 모바일에서도 정렬 유지 */
+    left: -2px !important; /* 모바일에서도 정렬 유지 */
     padding: 1px 4px !important;
     font-size: 12px !important;
   }

--- a/src/styles/Cursors.css
+++ b/src/styles/Cursors.css
@@ -1,56 +1,46 @@
-/* 커서 깜빡임 애니메이션 */
-@keyframes cursor-blink {
-  0%,
-  50% {
-    opacity: 1;
-  }
-  51%,
-  100% {
-    opacity: 0.3;
-  }
-}
-
-/* 선택 영역 기본 스타일 */
-[class^="yRemoteSelection-"] {
-  border-radius: 0.125rem !important;
-  transition: background-color 0.15s ease !important;
-}
-
-/* 커서 헤드 기본 스타일 */
-[class^="yRemoteSelectionHead"] {
-  position: relative !important;
-  width: 2px !important;
-}
-
-/* 커서 깜빡이는 라인 */
-[class^="yRemoteSelectionHead"]::before {
+[class*="yRemoteSelectionHead"] {
   position: absolute !important;
-  top: 0 !important;
-  left: 0 !important;
-  width: 2px !important;
+  box-sizing: border-box !important;
   height: 100% !important;
-  content: "" !important;
-  animation: cursor-blink 1s infinite !important;
-  will-change: opacity !important;
+  padding: 4px !important;
+  margin: -2px !important;
+  border-left: 2px solid var(--user-color, orangered) !important;  
 }
 
-/* 사용자 이름 라벨 */
-[class^="yRemoteSelectionHead"]::after {
+/* 라벨 */
+[class*="yRemoteSelectionHead"]::after {
   position: absolute !important;
-  top: 0 !important;
-  left: 4px !important;
-  z-index: 10000 !important;
-  padding: 0.25rem 0.5rem !important;
-  font: 500 0.6875rem / 1 system-ui, -apple-system, sans-serif !important;
+  top: -1.3em !important;
+  left: -2px !important;
+  z-index: 100 !important;
+  padding: 2px 6px !important;
+  font: 600 8px/normal system-ui, -apple-system, sans-serif;
   color: white !important;
   white-space: nowrap !important;
-  pointer-events: none !important;
-  border-radius: 0.375rem !important;
+  pointer-events: auto !important;
+  user-select: none !important;
+  background: var(--user-color, orangered) !important;
+  border: 0 !important;
+  border-radius: 6px !important;
+  border-bottom-left-radius: 0 !important;
   box-shadow: 0 0.125rem 0.5rem rgba(0, 0, 0, 0.2) !important;
-  opacity: 0.9 !important;
 }
 
-/* 만약 다크모드를 한다면 */
+/* 커서에 hover 시 라벨 표시 */
+[class*="yRemoteSelectionHead-"]:hover::after {
+  font: 600 12px/normal system-ui, -apple-system, sans-serif;
+}
+
+/* 호버중에 린트 미표시 */
+body:has([class*="yRemoteSelectionHead-"]:hover) .monaco-editor .hover-row {
+  display: none !important;
+}
+
+/* 전체 커서 표시 on/off */
+body.labels-hidden [class*="yRemoteSelectionHead-"]:after {
+  display: none !important;
+}
+
 @media (prefers-color-scheme: dark) {
   [class^="yRemoteSelectionHead"]::after {
     box-shadow: 0 0.125rem 0.5rem rgba(0, 0, 0, 0.4) !important;
@@ -59,9 +49,9 @@
 
 @media (max-width: 768px) {
   [class^="yRemoteSelectionHead"]::after {
-    left: 3px !important;
-    padding: 0.125rem 0.375rem !important;
-    font-size: 0.625rem !important;
+    left: -2px !important;  /* 모바일에서도 정렬 유지 */
+    padding: 1px 4px !important;
+    font-size: 12px !important;
   }
 }
 
@@ -71,17 +61,3 @@
     box-shadow: 0 0.125rem 0.5rem rgba(0, 0, 0, 0.6) !important;
   }
 }
-
-@media (prefers-reduced-motion: reduce) {
-  @keyframes cursor-blink {
-    0%,
-    100% {
-      opacity: 1;
-    }
-  }
-
-  [class^="yRemoteSelectionHead"]::before {
-    animation: none !important;
-  }
-}
-

--- a/src/styles/Cursors.css
+++ b/src/styles/Cursors.css
@@ -1,0 +1,87 @@
+/* 커서 깜빡임 애니메이션 */
+@keyframes cursor-blink {
+  0%,
+  50% {
+    opacity: 1;
+  }
+  51%,
+  100% {
+    opacity: 0.3;
+  }
+}
+
+/* 선택 영역 기본 스타일 */
+[class^="yRemoteSelection-"] {
+  border-radius: 0.125rem !important;
+  transition: background-color 0.15s ease !important;
+}
+
+/* 커서 헤드 기본 스타일 */
+[class^="yRemoteSelectionHead"] {
+  position: relative !important;
+  width: 2px !important;
+}
+
+/* 커서 깜빡이는 라인 */
+[class^="yRemoteSelectionHead"]::before {
+  position: absolute !important;
+  top: 0 !important;
+  left: 0 !important;
+  width: 2px !important;
+  height: 100% !important;
+  content: "" !important;
+  animation: cursor-blink 1s infinite !important;
+  will-change: opacity !important;
+}
+
+/* 사용자 이름 라벨 */
+[class^="yRemoteSelectionHead"]::after {
+  position: absolute !important;
+  top: 0 !important;
+  left: 4px !important;
+  z-index: 10000 !important;
+  padding: 0.25rem 0.5rem !important;
+  font: 500 0.6875rem / 1 system-ui, -apple-system, sans-serif !important;
+  color: white !important;
+  white-space: nowrap !important;
+  pointer-events: none !important;
+  border-radius: 0.375rem !important;
+  box-shadow: 0 0.125rem 0.5rem rgba(0, 0, 0, 0.2) !important;
+  opacity: 0.9 !important;
+}
+
+/* 만약 다크모드를 한다면 */
+@media (prefers-color-scheme: dark) {
+  [class^="yRemoteSelectionHead"]::after {
+    box-shadow: 0 0.125rem 0.5rem rgba(0, 0, 0, 0.4) !important;
+  }
+}
+
+@media (max-width: 768px) {
+  [class^="yRemoteSelectionHead"]::after {
+    left: 3px !important;
+    padding: 0.125rem 0.375rem !important;
+    font-size: 0.625rem !important;
+  }
+}
+
+@media (prefers-contrast: high) {
+  [class^="yRemoteSelectionHead"]::after {
+    border: 1px solid rgba(255, 255, 255, 0.5) !important;
+    box-shadow: 0 0.125rem 0.5rem rgba(0, 0, 0, 0.6) !important;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  @keyframes cursor-blink {
+    0%,
+    100% {
+      opacity: 1;
+    }
+  }
+
+  [class^="yRemoteSelectionHead"]::before {
+    animation: none !important;
+  }
+}
+


### PR DESCRIPTION
## 개요

사용자 커서를 나타내는 기능입니다. 전체 추가된 파일은 2개입니다.
src/components/ide/editor-part/Cursors.tsx
src/styles/Cursors.css
사용자 이름을 포함한 커서 부분을 동적으로 나타내는 코드와 커스텀용으로 순수 css파일입니다.
정형화된 형태가 아니라서 일단 확인과 커스텀이 쉽도록 css로 작성됐습니다.

실제 파일의 흐름은 유저 스토어 -> yprovider에 유저 정보 저장 -> 커서 쪽에서 유저정보 표시 입니다.

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)
<img width="1837" height="360" alt="image" src="https://github.com/user-attachments/assets/34bceed4-3570-49a3-b0cf-8c36e5d408a9" />

v2 개선 버전
<img width="953" height="218" alt="image" src="https://github.com/user-attachments/assets/3c668e62-71cd-4df4-b219-d54bcc8a554a" />

## 💬 공유사항 to 리뷰어
(7-28/v2)
일단 이런 형태로 개선했습니다.
**커서**
- 라벨 자체를 숨겨봤는데 커서단이 너무 작아서 사용감이 떨어졌습니다.
- 그래서 추가적으로 라벨이 너무 크지 않도록 글씨 크기 자체를 줄였습니다.
- 이후 호버시 글씨 크기 증가 + 이름(이메일) 형식으로 확장된 방식으로 사용자를 볼 수 있도록 수정했습니다.
- 커서 라벨을 숨기는 토글 기능을 넣어뒀습니다. 이후 우클릭 메뉴나 헤더 혹은 사이드 바쪽에서 실행이 가능하도록 할 예정입니다.

**스토어**
- id 부분을 email로 수정했습니다.
- 유저 스토어 부분에 persist를 도입해서 상태 관리 부분을 개선했습니다.

(7-28/v1)
현 시점에서 색상은 랜덤하게 배정하고 있습니다. 또한 사용자 이름을 커서의 오른쪽 위에 표시하는 방법도 생각했었는데 이 경우 커서가 윗줄의 코드를 가리는 문제가 존재해서 일단 커서의 오른쪽으로 표시하도록 변경했습니다. 이 부분은 위치 조정만 하면 괜찮은 부분이라 필요하다면 이후 쉽게 수정이 가능합니다.

코드를 보면 인라인 스타일로 css를 적용하는 부분이 있는데 커서를 생성하는 클래스인 yRemoteSelection류 자체가 라이브러리 쪽에서 제공되어서 인라인 스타일을 사용하는 것이 가장 깔끔했습니다.(사용자별 동적 할당을 위해서기도 합니다)
```
        return `
          .yRemoteSelection-${userId} { background-color: ${user.color}40 !important; }
          .yRemoteSelectionHead-${userId}::before { background-color: ${user.color} !important; }
          .yRemoteSelectionHead-${userId}::after {...}

```
커서 표시는 사용자가 현재 편집하고 있는 탭에서만 이루어집니다.
예를 들어 파일 a와 파일 b가 있다면 파일 a에서 편집하고 있는 다른 사용자가 탭을 파일 b로 바꿀 경우 커서가 파일 b쪽으로 이동합니다.

추가적으로
뭔가 에디터쪽 변경사항이 많아보이지만 이전 pr했던 부분이 머지가 안돼서 그렇습니다. 실제로는 2줄 변경됐습니다.
저번 pr에서 커밋한 스토어 부분이 아직 dev에 반영이 안돼서 자동으로 같이 push되었는데 이전에 올린 pr과 동일한 파일입니다.
실질적으로는 이전에 pr했던 부분에서 에디터 부분 중 커서 적용하는 부분 2줄이 겹칩니다. 이부분은 머지 순서를 조정하거나 이전 pr을 클로즈하고 현재 pr을 적용시키면 될것 같습니다.
이전 pr에 포함시키자니 신규 기능 추가라 부득이하게 pr을 분리하게 됐습니다.

**여기부터는 논의 사항입니다.**
1. 사용자의 컬러 부분을 자신이 선택할 수 있게 하는 것이 좋을까요?
2. 혹시 커서의 모양을 다른 이쁜 모양으로 바꾸는 것이 좋을까요?
3. 현재 커서 사용자 이름 부분이 흰색인데 검은색이 더 나을까요?

<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] Eslint 및 Prettier 규칙을 준수했습니다.
- [x] origin/main에서의 최신 커밋을 확인하고 반영했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
